### PR TITLE
Change dependency `railties < 6.0`

### DIFF
--- a/octicons-rails.gemspec
+++ b/octicons-rails.gemspec
@@ -11,5 +11,5 @@ Gem::Specification.new do |s|
   s.summary     = 'Awesome Github Octicons with Rails asset pipeline'
   s.description = ''
   s.license     = 'MIT'
-  s.add_dependency 'railties', '>= 3.2', '< 5.1'
+  s.add_dependency 'railties', '>= 3.2', '< 6.0'
 end


### PR DESCRIPTION
Fix https://github.com/torbjon/octicons-rails/issues/5

I believe this gem works without modification in rails 5.
(But bundled `octicons` version is old)